### PR TITLE
IOC now waits far less until it goes into error, also goes back after PV updates

### DIFF
--- a/anc350MotorApp/src/anc350AsynMotor.c
+++ b/anc350MotorApp/src/anc350AsynMotor.c
@@ -525,7 +525,7 @@ static int motorAxisGet( AXIS_HDL pAxis, int location, int *value, int logGlobal
 
   if (status!=asynSuccess){
     comms++;
-    if (comms > 200){
+    if (comms > 20){
       motorParam->setInteger( pAxis->params, motorAxisCommError, 1 );
       drvPrint( drvPrintParam, TRACE_ERROR, "anc350AsynMotorGet: Comms error.\n");
     }
@@ -975,6 +975,10 @@ static void drvAnc350GetAxisStatus( AXIS_HDL pAxis, asynUser * pasynUser, epicsU
 			/* Hump detected? */
       		hump = (value&ANC_STATUS_HUMP) >> 1;
 		}
+		else
+		{
+			motorAxisforceCallback(pAxis);
+		}
 
       /* Get the current amplitude */
 			status = motorAxisGet( pAxis, ID_ANC_AMPL, &value, 0 );
@@ -1015,6 +1019,10 @@ static void drvAnc350GetAxisStatus( AXIS_HDL pAxis, asynUser * pasynUser, epicsU
         status = motorParam->setDouble(pAxis->params, motorAxisPosition, position);
         motorParam->setDouble(pAxis->params, motorAxisEncoderPosn, position);
       }
+	  else
+	  {
+		  motorAxisforceCallback(pAxis);
+	  }
 
 			/* Check for hard limit.  Only hump available so notify limit by checking direction */
 			if (hump && (humpstatus == asynSuccess)){


### PR DESCRIPTION
### Description of work

IOC no longer waits for 200 comm errors before raising invalid alarm.
-Waiting for multiple errors was kept in case it had some sort of purpose (e.g. frequent brief disconnects from controller)
IOC now goes back into error after an update to the motor PV clears the error, via a forced callback.
 
### Ticket

ISISComputingGroup/IBEX#4618
### Acceptance criteria
IOC functions as before, with the exception of comm errors now being fixed. IOC additionally passes all automatic tests, including the new test for alarms not clearing after a PV updates.
### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?